### PR TITLE
Update MSRV to 1.89 for File lock APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Compile-time temporary directory shared by multiple crates and er
 documentation = "https://docs.rs/scratch"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/scratch"
-rust-version = "1.0"
+rust-version = "1.89"
 
 [lib]
 name = "scratch"


### PR DESCRIPTION
The file lock APIs were only added in Rust 1.89, which is a *teeeny bit* newer than the previous MSRV of 1.0.